### PR TITLE
Add missing closing bracket

### DIFF
--- a/src/tags/NfcTagsIntfType2.cpp
+++ b/src/tags/NfcTagsIntfType2.cpp
@@ -141,7 +141,7 @@ uint8_t NfcTagsIntfType2::handleDump(void)
     }
 
     return status;
- 
+}
 
 void NfcTagsIntfType2::handleData(uint8_t status, uint16_t id, void *data)
 {


### PR DESCRIPTION
Add missing closing bracket for uint8_t NfcTagsIntfType2::handleDump(void)